### PR TITLE
Adds a useful .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+bin
+lib
+lib64
+pyvenv.cfg


### PR DESCRIPTION
This .gitignore file has ignore rules for python byte code files,
python 3 pycache folder and venv related files and folders.